### PR TITLE
feat: forced switch to 25.05

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#c1835d",
+    "activityBar.background": "#c1835d",
+    "activityBar.foreground": "#15202b",
+    "activityBar.inactiveForeground": "#15202b99",
+    "activityBarBadge.background": "#a3dcb8",
+    "activityBarBadge.foreground": "#15202b",
+    "commandCenter.border": "#e7e7e799",
+    "sash.hoverBorder": "#c1835d",
+    "statusBar.background": "#aa6941",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#c1835d",
+    "statusBarItem.remoteBackground": "#aa6941",
+    "statusBarItem.remoteForeground": "#e7e7e7",
+    "titleBar.activeBackground": "#aa6941",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveBackground": "#aa694199",
+    "titleBar.inactiveForeground": "#e7e7e799"
+  },
+  "peacock.color": "#aa6941"
+}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,7 +11,7 @@ tasks:
   switch:
     desc: Build and apply the system configuration
     cmds:
-      - darwin-rebuild switch --flake .#{{- .HOSTNAME -}} {{- .CLI_ARGS }}
+      - sudo darwin-rebuild switch --flake .#{{- .HOSTNAME -}} {{- .CLI_ARGS }}
 
   update:
     desc: Run flake update (specify an argument after '--' for updating a single package)
@@ -66,7 +66,20 @@ tasks:
       - task: macos_install_brew
 
   reinstall:
-    desc: Reinstall nix darwin
+    desc: Reinstall nix-darwin
     cmds:
-      - nix run nix-darwin -- switch --flake .#{{ .HOSTNAME }}
-# sudo -i nix-env --uninstall nix
+      - sudo nix run nix-darwin/nix-darwin-25.05 -- switch --flake .#{{ .HOSTNAME }}
+
+  uninstall:
+    desc: Remove nix darwin
+    prompt:
+      - This will remove nix-darwin. Are you sure?
+    cmds:
+      - sudo nix --extra-experimental-features "nix-command flakes" run nix-darwin#darwin-uninstaller
+
+  uninstall_nix:
+    desc: Remove nix
+    prompt:
+      - This will remove Nix entirely! Are you sure?
+    cmds:
+      - sudo -i nix-env --uninstall nix

--- a/flake.lock
+++ b/flake.lock
@@ -7,16 +7,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1741126078,
-        "narHash": "sha256-ng0a4cIq3c9E3iGKomlwqKzVYs2RLOzQho2U1Mc2sqU=",
+        "lastModified": 1748044287,
+        "narHash": "sha256-9bJzyUX5+HXYmI60WMGYXXDdhGbSh1Le6yBM4og3K7E=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "c172f50b55b087f8e7801631de977461603bb976",
+        "rev": "2456ff5c95edfc3b197cb012b947012faed77591",
         "type": "github"
       },
       "original": {
         "owner": "LnL7",
-        "ref": "nix-darwin-24.11",
+        "ref": "nix-darwin-25.05",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -64,16 +64,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1739757849,
-        "narHash": "sha256-Gs076ot1YuAAsYVcyidLKUMIc4ooOaRGO0PqTY7sBzA=",
+        "lastModified": 1748226808,
+        "narHash": "sha256-GaBRgxjWO1bAQa8P2+FDxG4ANBVhjnSjBms096qQdxo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9d3d080aec2a35e05a15cedd281c2384767c2cfe",
+        "rev": "83665c39fa688bd6a1f7c43cf7997a70f6a109f9",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.11",
+        "ref": "release-25.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -102,8 +102,8 @@
     "nixpkgs": {
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-hXUyO337QzfApfNXLrQrhBUOhZAWp0wxVNTxKxjzun4=",
-        "path": "/nix/store/1jnazvjnsps6xnscm77j8a0nfbdl3z7a-source",
+        "narHash": "sha256-0etyrY6jOzFwVILODzMc43MTtUanxzFSaqe3kVLvew4=",
+        "path": "/nix/store/lp16sdbzvyk1xlc94ykxmmjg2gs1cg6w-source",
         "type": "path"
       },
       "original": {
@@ -113,16 +113,16 @@
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1741838297,
-        "narHash": "sha256-0etyrY6jOzFwVILODzMc43MTtUanxzFSaqe3kVLvew4=",
+        "lastModified": 1748192983,
+        "narHash": "sha256-FpKC8sZCzNoeCtHJmYiqafYt5A1JzQ44opT46M/qe4I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "80b53fdb4f883238807ced86db41be809d60f3b5",
+        "rev": "b26c8c4da0fe0b4e496f2a432140795dabe2c8e2",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-24.11-darwin",
+        "ref": "nixpkgs-25.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -22,11 +22,11 @@
   # Each item in `inputs` will be passed as a parameter to the `outputs` function after being pulled and built.
   inputs = {
     # nixpkgs-darwin.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    nixpkgs-darwin.url = "github:nixos/nixpkgs/nixpkgs-24.11-darwin";
+    nixpkgs-darwin.url = "github:nixos/nixpkgs/nixpkgs-25.05-darwin";
 
     # home-manager, used for managing user configuration
     home-manager = {
-      url = "github:nix-community/home-manager/release-24.11";
+      url = "github:nix-community/home-manager/release-25.05";
       # The `follows` keyword in inputs is used for inheritance.
       # Here, `inputs.nixpkgs` of home-manager is kept consistent with the `inputs.nixpkgs` of the current flake,
       # to avoid problems caused by different versions of nixpkgs dependencies.
@@ -34,7 +34,7 @@
     };
 
     darwin = {
-      url = "github:LnL7/nix-darwin/nix-darwin-24.11";
+      url = "github:LnL7/nix-darwin/nix-darwin-25.05";
       inputs.nixpkgs.follows = "nixpkgs-darwin";
     };
 

--- a/hosts/simpleton/home-manager.nix
+++ b/hosts/simpleton/home-manager.nix
@@ -2,5 +2,6 @@
   imports = [
     ../../modules/home-manager
     ./home-manager/core.nix
+    ./home-manager/k8s.nix
   ];
 }

--- a/hosts/simpleton/home-manager/k8s.nix
+++ b/hosts/simpleton/home-manager/k8s.nix
@@ -1,0 +1,27 @@
+{pkgs, ...}: {
+  programs = {
+    k9s = {
+      hotkey = {
+        hotKeys = {
+          shift-k = {
+            shortCut = "Shift-K";
+            description = "Flux Kustomizations (all namespaces)";
+            command = "kustomize.toolkit.fluxcd.io/v1/kustomizations all";
+          };
+          shift-h = {
+            shortCut = "Shift-H";
+            description = "HelmReleases (all namespaces)";
+            command = "helmreleases.helm.toolkit.fluxcd.io all";
+          };
+          shift-f = {
+            shortCut = "Shift-F";
+            description = "FluxInstances (all namespaces)";
+            command = "fluxinstances.fluxcd.controlplane.io all";
+          };
+        };
+      };
+    };
+    # TODO: plugins
+    # https://github.com/derailed/k9s/blob/master/plugins/flux.yaml
+  };
+}

--- a/modules/base/nix-core.nix
+++ b/modules/base/nix-core.nix
@@ -1,4 +1,5 @@
 {
+  username,
   pkgs,
   lib,
   ...
@@ -13,12 +14,13 @@
   nixpkgs.config.allowUnfree = true;
 
   # Auto upgrade nix package and the daemon service.
-  services.nix-daemon.enable = true;
+  # services.nix-daemon.enable = true;
   # Use this instead of services.nix-daemon.enable if you
   # don't wan't the daemon service to be managed for you.
   # nix.useDaemon = true;
-
+  
   nix.package = pkgs.nix;
+  nix.enable = true;
 
   # do garbage collection weekly to keep disk usage low
   nix.gc = {

--- a/modules/base/system.nix
+++ b/modules/base/system.nix
@@ -1,4 +1,8 @@
-{pkgs, ...}:
+{
+  pkgs,
+  username,
+  ...
+}:
 ###################################################################################
 #
 #  macOS's System configuration
@@ -11,12 +15,13 @@
 ###################################################################################
 {
   system = {
+    primaryUser = username;
     stateVersion = 5;
     # activationScripts are executed every time you boot the system or run `nixos-rebuild` / `darwin-rebuild`.
-    activationScripts.postUserActivation.text = ''
+    activationScripts.postActivation.text = ''
       # activateSettings -u will reload the settings from the database and apply them to the current session,
       # so we do not need to logout and login again to make the changes take effect.
-      /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
+      sudo -u ${username} /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
     '';
 
     activationScripts.diff = {
@@ -271,7 +276,7 @@
   };
 
   # Add ability to used TouchID for sudo authentication
-  security.pam.enableSudoTouchIdAuth = true;
+  security.pam.services.sudo_local.touchIdAuth = true;
 
   # Create /etc/zshrc that loads the nix-darwin environment.
   # this is required if you want to use darwin's default shell - zsh
@@ -284,19 +289,13 @@
   # Fonts
   fonts = {
     packages = with pkgs; [
-      # nerdfonts
-      # https://github.com/NixOS/nixpkgs/blob/nixos-24.05/pkgs/data/fonts/nerdfonts/shas.nix
-      (nerdfonts.override {
-        fonts = [
-          "Meslo"
-          # symbols icon only
-          "NerdFontsSymbolsOnly"
-          # Characters
-          "FiraCode"
-          "JetBrainsMono"
-          "Iosevka"
-        ];
-      })
+      # nerd-fonts
+      # https://github.com/NixOS/nixpkgs/blob/25.05/pkgs/data/fonts/nerd-fonts/manifests/fonts.json
+      nerd-fonts.meslo-lg
+      nerd-fonts.symbols-only
+      nerd-fonts.fira-code
+      nerd-fonts.jetbrains-mono
+      nerd-fonts.iosevka
     ];
   };
 }

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -27,7 +27,7 @@
     # You can update Home Manager without changing this value. See
     # the Home Manager release notes for a list of state version
     # changes in each release.
-    stateVersion = "24.05";
+    stateVersion = "25.05";
   };
 
   # Let Home Manager install and manage itself.

--- a/modules/home-manager/k8s.nix
+++ b/modules/home-manager/k8s.nix
@@ -13,28 +13,17 @@
           };
         };
       };
-      hotkey = {
-        hotKeys = {
-          shift-k = {
-            shortCut = "Shift-K";
-            description = "Flux Kustomizations (all namespaces)";
-            command = "kustomize.toolkit.fluxcd.io/v1/kustomizations all";
-          };
-          shift-h = {
-            shortCut = "Shift-H";
-            description = "HelmReleases (all namespaces)";
-            command = "helmreleases.helm.toolkit.fluxcd.io all";
-          };
-          shift-f = {
-            shortCut = "Shift-F";
-            description = "FluxInstances (all namespaces)";
-            command = "fluxinstances.fluxcd.controlplane.io all";
-          };
-        };
-      };
+      # hotkey = {
+      #   hotKeys = {
+      #     shift-k = {
+      #       shortCut = "Shift-K";
+      #       description = "Flux Kustomizations (all namespaces)";
+      #       command = "kustomize.toolkit.fluxcd.io/v1/kustomizations all";
+      #     };
+      #   };
+      # };
     };
     # TODO: plugins
-    # https://github.com/derailed/k9s/blob/master/plugins/flux.yaml
     # https://github.com/derailed/k9s/blob/master/plugins/log-stern.yaml
     krewfile = {
       enable = true;

--- a/modules/home-manager/shell.nix
+++ b/modules/home-manager/shell.nix
@@ -16,7 +16,7 @@
     enable = true;
     enableCompletion = true;
 
-    initExtra = ''
+    initContent = ''
       export PATH="$HOME/.krew/bin:$HOME/.local/bin:$HOME/go/bin:$PATH"
 
       # Devbox globals setup


### PR DESCRIPTION
Since the `nix-darwin` flake now requires that `system activation must now be run as root` here's the changes required to still build.

For context, see:
* https://github.com/nix-darwin/nix-darwin/pull/1341
* https://github.com/nix-darwin/nix-darwin/issues/1462