### PR TITLE
feat: add herdr to Truman tools

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,6 +131,25 @@
         "type": "github"
       }
     },
+    "herdr": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1784721549,
+        "narHash": "sha256-+Kb2z+Pwvq0k73kIRSpqMrDnfYS8vY06gs4AdvazA9c=",
+        "owner": "ogulcancelik",
+        "repo": "herdr",
+        "rev": "c234f221f9be698bc0501c60459e1ae8e67df6c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ogulcancelik",
+        "repo": "herdr",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -177,7 +196,7 @@
       "inputs": {
         "bun2nix": "bun2nix",
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "systems": "systems_3",
         "treefmt-nix": "treefmt-nix"
       },
@@ -197,16 +216,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784555310,
-        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
+        "lastModified": 1779357205,
+        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
+        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -245,6 +264,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1784555310,
+        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1784432872,
         "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
         "owner": "nixos",
@@ -264,13 +299,35 @@
         "darwin": "darwin",
         "disko": "disko",
         "flake-utils": "flake-utils",
+        "herdr": "herdr",
         "home-manager": "home-manager",
         "krewfile": "krewfile",
         "llm-agents": "llm-agents",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-darwin": "nixpkgs-darwin",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "sops-nix": "sops-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "herdr",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783577481,
+        "narHash": "sha256-EWMxOWrJ031f8f/lrcEmhTRs4npw1/5N3Hcjin846c8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "4cdea398dc491b082dccdce0fad1ed0b75fa3394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "sops-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,10 @@
       url = "github:numtide/llm-agents.nix";
     };
 
+    herdr = {
+      url = "github:ogulcancelik/herdr";
+    };
+
   };
 
   # The `outputs` function will return all the build results of the flake.

--- a/hosts/Truman/home-manager/tools.nix
+++ b/hosts/Truman/home-manager/tools.nix
@@ -1,4 +1,8 @@
-{pkgs, ...}: {
+{
+  pkgs,
+  herdr,
+  ...
+}: {
   home.packages = with pkgs; [
     # TODO: it may make sense to migrate a subset of this to a devbox (global or local) config
 
@@ -44,6 +48,7 @@
     kubie
     ctlptl
     argocd
+    herdr.packages.${pkgs.stdenv.hostPlatform.system}.herdr
 
     # AI tools
     # open-webui


### PR DESCRIPTION
## Summary

Adds [`github:ogulcancelik/herdr`](https://github.com/ogulcancelik/herdr) as a flake input and installs it via home-manager on Truman alongside the other Kubernetes tooling.

## Changes

- `flake.nix`: new input `herdr = { url = "github:ogulcancelik/herdr"; }`.
- `flake.lock`: locked to the current revision (brings in a transitive `rust-overlay`/`nixpkgs` for herdr's own build; both isolated to the herdr input).
- `hosts/Truman/home-manager/tools.nix`: destructure `herdr` from specialArgs and add `herdr.packages.${pkgs.stdenv.hostPlatform.system}.herdr` to `home.packages`, grouped with the existing Kubernetes tools (`trivy`, `kubie`, `ctlptl`, `argocd`).

## Test plan

- [x] `nix eval .#darwinConfigurations.Truman.config.system.build.toplevel.drvPath` succeeds.
- [ ] `sudo task diff` on Truman shows the herdr derivation being added.
- [ ] `sudo task switch` on Truman applies cleanly and `which herdr` resolves.